### PR TITLE
added Micromegas ADC distributions

### DIFF
--- a/QA-Micromegas.ipynb
+++ b/QA-Micromegas.ipynb
@@ -366,6 +366,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# ADC distributions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%cpp\n",
+    "\n",
+    "Draw( qa_file_new, qa_file_ref, hist_name_prefix, \"adc\" )-> Draw();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# residuals, errors and pulls"
    ]
   },


### PR DESCRIPTION
Added ADC distributions to micromegas QA page

![Screenshot_20210604_103639](https://user-images.githubusercontent.com/22907496/120834920-e6fe8f80-c520-11eb-8030-ced6aaa93894.png)

Depends on https://github.com/sPHENIX-Collaboration/coresoftware/pull/1197
Also need merge to QA-tracking-high-occupancy branch
